### PR TITLE
introduce channellogos

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Available extras:
 directfb
 directfbsamples
 dynamite
+channellogos
 easyvdr
 permashift
 
@@ -230,6 +231,9 @@ LibreELEC and CoreELEC use kernel built-in remote support as default. See [Libre
 
 ### Enabled plugins
 ```/storage/.config/vdropt/enabled_plugins``` contains a list of the plugins to autostart with VDR. Simply edit the file and add other plugins of your choice to the already pre-activated ones. 
+
+### Channel logos
+```/usr/local/vdrshare/logos``` contains the channel logos, if they have been built with ```-e channellogos```. 
 
 ### VDR specific configuration
 After basic configuration is done you probably need to adapt VDR's conf files.  

--- a/config/extras.list
+++ b/config/extras.list
@@ -24,3 +24,6 @@ easyvdr:EXTRA_EASYVDR
 
 # permashift plugin/patch
 permashift:EXTRA_PERMASHIFT
+
+# install channel logos
+channellogos:EXTRA_CHANNELLOGOS

--- a/packages/vdr/_vdr-plugin-skindesigner/conf.d/skindesigner.conf
+++ b/packages/vdr/_vdr-plugin-skindesigner/conf.d/skindesigner.conf
@@ -7,5 +7,5 @@
 [skindesigner]
 -s /storage/.config/vdropt/plugins/skindesigner/skins
 -i /storage/.config/vdropt/plugins/skindesigner/installerskins
--l /storage/.config/vdropt/plugins/skindesigner/logos
+-l /usr/local/vdrshare/logos
 -e /storage/cache/epgimages

--- a/packages/vdr/_vdr-plugin-skinnopacity/conf.d/skinnopacity.conf
+++ b/packages/vdr/_vdr-plugin-skinnopacity/conf.d/skinnopacity.conf
@@ -4,3 +4,4 @@
 # -l <LOGOPATH>, --logopath=<LOGOPATH>       Set directory where Channel Logos are stored.
 
 [skinnopacity]
+-l /usr/local/vdrshare/logos

--- a/packages/vdr/_vdr-plugin-skinnopacity/conf.d/skinnopacity_settings.ini
+++ b/packages/vdr/_vdr-plugin-skinnopacity/conf.d/skinnopacity_settings.ini
@@ -1,4 +1,4 @@
 [EasyPluginManager]
 AutoRun = false
 Stop = true
-Args =
+Args = -l /usr/local/vdrshare/logos

--- a/packages/vdr/_vdr-plugin-tvguide/conf.d/tvguide.conf
+++ b/packages/vdr/_vdr-plugin-tvguide/conf.d/tvguide.conf
@@ -1,1 +1,2 @@
 [tvguide]
+-l /usr/local/vdrshare/logos

--- a/packages/vdr/_vdr-plugin-tvguide/conf.d/tvguide_settings.ini
+++ b/packages/vdr/_vdr-plugin-tvguide/conf.d/tvguide_settings.ini
@@ -1,4 +1,4 @@
 [EasyPluginManager]
 AutoRun = false
 Stop = true
-Args =
+Args = -l /usr/local/vdrshare/logos

--- a/packages/vdr/vdr-depends/_MP_Logos/package.mk
+++ b/packages/vdr/vdr-depends/_MP_Logos/package.mk
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+PKG_NAME="_MP_Logos"
+PKG_VERSION="2e12ba4707295a5f3f48170117142d0c42505f7f"
+PKG_SHA256="79419c83b4ed6500306c4a10c28e3b7fad91fc6fa0afb68f1aa385abb9534426"
+PKG_LICENSE="GPL3"
+PKG_SITE="https://github.com/MegaV0lt/MP_Logos"
+PKG_URL="https://github.com/MegaV0lt/MP_Logos/archive/${PKG_VERSION}.zip"
+PKG_SOURCE_DIR="MP_Logos-${PKG_VERSION}"
+PKG_DEPENDS_TARGET="toolchain _mediaportal-de-logos"
+PKG_TOOLCHAIN="manual"
+
+make_target() {
+    export MP_LOGODIR="$(get_install_dir _mediaportal-de-logos)/usr/local/vdrshare/logofiles"
+    export MAPPING="$(get_install_dir _mediaportal-de-logos)/usr/local/vdrshare/logofiles/LogoMapping.xml"
+    export LOGODIR="${PKG_BUILD}/logos"
+    export AUTO_UPDATE="false"
+    export LOGO_VARIANT="Light"
+    export TO_LOWER="A-Z"
+
+    touch ${PKG_BUILD}/mp_logos.conf
+
+    mkdir -p ${LOGODIR}
+
+    cd ${MP_LOGODIR}
+    bash ${PKG_BUILD}/mp_logos.sh -c ${PKG_BUILD}/mp_logos.conf
+
+    mkdir -p ${INSTALL}/usr/local/vdrshare/logos
+    cp -R ${LOGODIR} ${INSTALL}/usr/local/vdrshare
+}

--- a/packages/vdr/vdr-depends/_MP_Logos/patches/0001-Fix-script-for-use-in-VDR-ELEC.patch
+++ b/packages/vdr/vdr-depends/_MP_Logos/patches/0001-Fix-script-for-use-in-VDR-ELEC.patch
@@ -1,0 +1,55 @@
+From b50ee15494cb4e04bc469e20b2879f5afd6d5bf3 Mon Sep 17 00:00:00 2001
+From: Andreas Baierl <ichgeh@imkreisrum.de>
+Date: Tue, 3 Jan 2023 12:04:14 +0100
+Subject: [PATCH] Fix script for use in VDR*ELEC
+
+Logo conversion is not working. Logos are png in standard size an light version.
+---
+ mp_logos.sh | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/mp_logos.sh b/mp_logos.sh
+index 4aef41f..66f8646 100755
+--- a/mp_logos.sh
++++ b/mp_logos.sh
+@@ -49,15 +49,19 @@ f_process_channellogo() {  # Verlinken der Senderlogos zu den gefundenen Kanäle
+   if [[ "$USE_SVG" == 'true' ]] ; then  # Die Originalen *.svg-Logos verwenden
+     EXT='svg'  # Erweiterung der Logo-Datei
+     if [[ "$LOGO_VARIANT" =~ 'Light' ]] ; then
++      LOGO_NAME="${MODE}/${FILE%.*}.${EXT}"
+       LOGO_FILE="${MP_LOGODIR}/${MODE}/${FILE%.*}.${EXT}"  # Light
+     else
++      LOGO_NAME="${MODE}/${FILE%.*} - Dark.${EXT}"  # Dark
+       LOGO_FILE="${MP_LOGODIR}/${MODE}/${FILE%.*} - Dark.${EXT}"  # Dark
+       if [[ ! -e "$LOGO_FILE" ]] ; then
+         f_log WARN "Logo $LOGO_FILE nicht gefunden! Verwende 'Light'-Version."
++        LOGO_NAME="${MODE}/${FILE%.*}.${EXT}"  # Fallback auf Light
+         LOGO_FILE="${MP_LOGODIR}/${MODE}/${FILE%.*}.${EXT}"  # Fallback auf Light
+       fi
+     fi
+   else  # Normaler Modus mit PNG-Logos
++    LOGO_NAME="${MODE}/${LOGO_VARIANT}/${FILE}"
+     LOGO_FILE="${MP_LOGODIR}/${MODE}/${LOGO_VARIANT}/${FILE}"
+   fi
+ 
+@@ -79,7 +83,7 @@ f_process_channellogo() {  # Verlinken der Senderlogos zu den gefundenen Kanäle
+       if [[ "$USE_PLAIN_LOGO" == 'true' ]] ; then
+         f_log INFO "Verlinke neue Datei (${FILE}) mit $channel"
+         # Symlink erstellen (--force überschreibt bereits existierenen Link)
+-        ln -f -s "$LOGO_FILE" "${LOGODIR}/${channel}" || \
++        ln -f -s "/usr/local/vdrshare/logofiles/$LOGO_NAME" "${LOGODIR}/${channel}" || \
+           { f_log ERR "Symbolischer Link \"${LOGODIR}/${channel}\" konnte nicht erstellt werden!" ; continue ;}
+       else
+         logoname="${LOGO_FILE##*/}"
+@@ -274,8 +278,6 @@ for line in "${mapping[@]}" ; do
+   esac
+ done
+ 
+-find "$LOGODIR" -xtype l -delete >> "${LOGFILE:-/dev/null}"  # Alte (defekte) Symlinks löschen
+-
+ [[ -n "$PROV" ]] && f_log "==> ${NO_CHANNEL:-Keine} Kanäle ohne Provider (${PROV}) in LogoMapping.xml"
+ [[ -n "$CHANNELSCONF" && "$NOPROV" -gt 0 ]] && f_log "==> $NOPROV Kanäle ohne Provider wurden in der Kanalliste gefunden"
+ f_log "==> ${N_LOGO:-0} neue oder aktualisierte Kanäle verlinkt (Vorhandene Logos: ${LOGO})"
+-- 
+2.30.2
+

--- a/packages/vdr/vdr-depends/_mediaportal-de-logos/package.mk
+++ b/packages/vdr/vdr-depends/_mediaportal-de-logos/package.mk
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+PKG_NAME="_mediaportal-de-logos"
+PKG_VERSION="4c43a379c9d80c68aa75aa25262921b4ff52a74c"
+PKG_SHA256="795bfbd6ac0c7e8a59cdbf12da0efb372a39b1d1c88306f80da5d79a01ea7de0"
+PKG_LICENSE="?"
+PKG_SITE="https://github.com/Jasmeet181/mediaportal-de-logos"
+PKG_SOURCE_DIR="mediaportal-de-logos-${PKG_VERSION}"
+PKG_URL="https://github.com/Jasmeet181/mediaportal-de-logos/archive/${PKG_VERSION}.zip"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_TOOLCHAIN="manual"
+
+make_target() {
+    INSTALLPATH="${INSTALL}/usr/local/vdrshare/logofiles"
+
+    mkdir -p ${INSTALLPATH}/Radio
+    cp -R ${PKG_BUILD}/Radio ${INSTALLPATH}
+
+    mkdir -p ${INSTALLPATH}/TV
+    cp -R ${PKG_BUILD}/TV ${INSTALLPATH}
+
+    cp  ${PKG_BUILD}/LogoMapping.xml ${INSTALLPATH}/LogoMapping.xml
+}

--- a/packages/virtual/vdr-all/package.mk
+++ b/packages/virtual/vdr-all/package.mk
@@ -127,6 +127,10 @@ if [ "${EXTRA_DIRECTFB2SAMPLES}" = "y" ]; then
 	#PKG_DEPENDS_TARGET+=" _DirectFB2-media-samples"
 fi
 
+if [ "${EXTRA_CHANNELLOGOS}" = "y" ]; then
+	PKG_DEPENDS_TARGET+=" _MP_Logos"
+fi
+
 post_install() {
   if [ "${PROJECT} = "Amlogic-ce" ] || [ "${PROJECT} = "Amlogic" ]; then
      # Fix some links


### PR DESCRIPTION
using https://github.com/Jasmeet181/mediaportal-de-logos and https://github.com/MegaV0lt/MP_Logos

Build it by setting the extra "channellogos"

Logos are placed at /usr/local/vdrshare/logos where the plugins' logo path should point to.
Skindesigner, skinnopacity and tvguide are set to that path already.

After an update you have to edit your plugins' conf file manually.

Signed-off-by: Andreas Baierl <ichgeh@imkreisrum.de>