### PR TITLE
channellogos: resize resulting image

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ LibreELEC and CoreELEC use kernel built-in remote support as default. See [Libre
 ```/storage/.config/vdropt/enabled_plugins``` contains a list of the plugins to autostart with VDR. Simply edit the file and add other plugins of your choice to the already pre-activated ones. 
 
 ### Channel logos
-```/usr/local/vdrshare/logos``` contains the channel logos, if they have been built with ```-e channellogos```. 
+```/usr/local/vdrshare/logos(Light|Dark)``` contain the channel logos, if they have been built with ```-e channellogos```. 
 
 ### VDR specific configuration
 After basic configuration is done you probably need to adapt VDR's conf files.  

--- a/packages/vdr/_vdr-plugin-skindesigner/conf.d/skindesigner.conf
+++ b/packages/vdr/_vdr-plugin-skindesigner/conf.d/skindesigner.conf
@@ -7,5 +7,5 @@
 [skindesigner]
 -s /storage/.config/vdropt/plugins/skindesigner/skins
 -i /storage/.config/vdropt/plugins/skindesigner/installerskins
--l /usr/local/vdrshare/logos
+-l /usr/local/vdrshare/logosLight
 -e /storage/cache/epgimages

--- a/packages/vdr/_vdr-plugin-skinnopacity/conf.d/skinnopacity.conf
+++ b/packages/vdr/_vdr-plugin-skinnopacity/conf.d/skinnopacity.conf
@@ -4,4 +4,4 @@
 # -l <LOGOPATH>, --logopath=<LOGOPATH>       Set directory where Channel Logos are stored.
 
 [skinnopacity]
--l /usr/local/vdrshare/logos
+-l /usr/local/vdrshare/logosLight

--- a/packages/vdr/_vdr-plugin-skinnopacity/conf.d/skinnopacity_settings.ini
+++ b/packages/vdr/_vdr-plugin-skinnopacity/conf.d/skinnopacity_settings.ini
@@ -1,4 +1,4 @@
 [EasyPluginManager]
 AutoRun = false
 Stop = true
-Args = -l /usr/local/vdrshare/logos
+Args = -l /usr/local/vdrshare/logosLight

--- a/packages/vdr/_vdr-plugin-tvguide/conf.d/tvguide.conf
+++ b/packages/vdr/_vdr-plugin-tvguide/conf.d/tvguide.conf
@@ -1,2 +1,2 @@
 [tvguide]
--l /usr/local/vdrshare/logos
+-l /usr/local/vdrshare/logosLight

--- a/packages/vdr/_vdr-plugin-tvguide/conf.d/tvguide_settings.ini
+++ b/packages/vdr/_vdr-plugin-tvguide/conf.d/tvguide_settings.ini
@@ -1,4 +1,4 @@
 [EasyPluginManager]
 AutoRun = false
 Stop = true
-Args = -l /usr/local/vdrshare/logos
+Args = -l /usr/local/vdrshare/logosLight

--- a/packages/vdr/vdr-depends/_MP_Logos/package.mk
+++ b/packages/vdr/vdr-depends/_MP_Logos/package.mk
@@ -13,18 +13,25 @@ PKG_TOOLCHAIN="manual"
 make_target() {
     export MP_LOGODIR="$(get_install_dir _mediaportal-de-logos)/usr/local/vdrshare/logofiles"
     export MAPPING="$(get_install_dir _mediaportal-de-logos)/usr/local/vdrshare/logofiles/LogoMapping.xml"
-    export LOGODIR="${PKG_BUILD}/logos"
     export AUTO_UPDATE="false"
-    export LOGO_VARIANT="Light"
     export TO_LOWER="A-Z"
 
     touch ${PKG_BUILD}/mp_logos.conf
-
-    mkdir -p ${LOGODIR}
-
     cd ${MP_LOGODIR}
-    bash ${PKG_BUILD}/mp_logos.sh -c ${PKG_BUILD}/mp_logos.conf
 
-    mkdir -p ${INSTALL}/usr/local/vdrshare/logos
+# Link "Light" variant
+    export LOGO_VARIANT="Light"
+    export LOGODIR="${PKG_BUILD}/logos${LOGO_VARIANT}"
+    mkdir -p ${LOGODIR}
+    bash ${PKG_BUILD}/mp_logos.sh -c ${PKG_BUILD}/mp_logos.conf
+    mkdir -p ${INSTALL}/usr/local/vdrshare/logos${LOGO_VARIANT}
+    cp -R ${LOGODIR} ${INSTALL}/usr/local/vdrshare
+
+# Link "Dark" variant
+    export LOGO_VARIANT="Dark"
+    export LOGODIR="${PKG_BUILD}/logos${LOGO_VARIANT}"
+    mkdir -p ${LOGODIR}
+    bash ${PKG_BUILD}/mp_logos.sh -c ${PKG_BUILD}/mp_logos.conf
+    mkdir -p ${INSTALL}/usr/local/vdrshare/logos${LOGO_VARIANT}
     cp -R ${LOGODIR} ${INSTALL}/usr/local/vdrshare
 }

--- a/packages/vdr/vdr-depends/_mediaportal-de-logos/package.mk
+++ b/packages/vdr/vdr-depends/_mediaportal-de-logos/package.mk
@@ -13,11 +13,15 @@ PKG_TOOLCHAIN="manual"
 make_target() {
     INSTALLPATH="${INSTALL}/usr/local/vdrshare/logofiles"
 
-    mkdir -p ${INSTALLPATH}/Radio
-    cp -R ${PKG_BUILD}/Radio ${INSTALLPATH}
+    mkdir -p ${INSTALLPATH}/Radio/.Light
+    cp -R ${PKG_BUILD}/Radio/.Light ${INSTALLPATH}/Radio
+    mkdir -p ${INSTALLPATH}/Radio/.Dark
+    cp -R ${PKG_BUILD}/Radio/.Dark ${INSTALLPATH}/Radio
 
-    mkdir -p ${INSTALLPATH}/TV
-    cp -R ${PKG_BUILD}/TV ${INSTALLPATH}
+    mkdir -p ${INSTALLPATH}/TV/.Light
+    cp -R ${PKG_BUILD}/TV/.Light ${INSTALLPATH}/TV
+    mkdir -p ${INSTALLPATH}/TV/.Dark
+    cp -R ${PKG_BUILD}/TV/.Dark ${INSTALLPATH}/TV
 
     cp  ${PKG_BUILD}/LogoMapping.xml ${INSTALLPATH}/LogoMapping.xml
 }


### PR DESCRIPTION
We just need to copy the "Light" and "Dark" directory. Drop the main directory and all the svgs.

The user can now choose between the two variants by selecting the right directory.

Signed-off-by: Andreas Baierl <ichgeh@imkreisrum.de>