### PR TITLE
zip_config.sh: Add option for better plugin development

### DIFF
--- a/packages/virtual/vdr-helper/zip_config.sh
+++ b/packages/virtual/vdr-helper/zip_config.sh
@@ -3,6 +3,7 @@
 INSTALL=$1
 PKG_DIR=$2
 PLUGIN=$3
+APIVERSION=$4
 
 # create default ${PLUGIN}.conf // will be overwritten, if we have something in the plugin directory
 mkdir -p ${INSTALL}/storage/.config/vdropt-sample/conf.d/
@@ -33,6 +34,14 @@ if find ${INSTALL}/storage/.config/vdropt -mindepth 1 -maxdepth 1 2>/dev/null | 
   cp -ar ${INSTALL}/storage/.config/vdropt/* ${INSTALL}/storage/.config/vdropt-sample
   rm -Rf ${INSTALL}/storage/.config/vdropt
  fi
+
+# create links for libs
+if [ -n "$APIVERSION" ]; then
+  mkdir -p ${INSTALL}/storage/.config/vdrlibs/save
+  mv ${INSTALL}/usr/local/lib/vdr/libvdr-${PLUGIN}.so.${APIVERSION} ${INSTALL}/storage/.config/vdrlibs/save/libvdr-${PLUGIN}.so.${APIVERSION}
+  ln -s /storage/.config/vdrlibs/libvdr-${PLUGIN}.so.${APIVERSION} ${INSTALL}/usr/local/lib/vdr/libvdr-${PLUGIN}.so.${APIVERSION}
+  ln -s /storage/.config/vdrlibs/save/libvdr-${PLUGIN}.so.${APIVERSION} ${INSTALL}/storage/.config/vdrlibs/libvdr-${PLUGIN}.so.${APIVERSION}
+fi
 
 # create config.zip
 cd ${INSTALL}


### PR DESCRIPTION
This adds some quirk for developing vdr plugins, which might be useful for plugin developers.
If "$(pkg-config --variable=apiversion vdr)" as the 4th argument for zip_config.sh is added in the plugin's package.mk, the plugin library will be installed into /storage/.config/vdrlibs/save. A link in /storage/.config/vdrlibs will point to that file and at last the necessary link in /usr/local/lib/vdr/libvdr-*.so.2.6.* will point again to /storage/.config/vdrlibs/libvdr-*.so.2.6.*.

This adds the possibility to copy your library binary at any place in /storage. You simply need to change the link in /storage/.config/vdrlibs to point to that file.

In my personal environment i have the server'ss LE build directory mounted as a nfs share into /storage/.config/vdrlibs/server and let /storage/.config/vdrlibs/libvdr-*.so.2.6.* point to the freshly built lib within the build directory.

So workflow is as follows:
- make code changes/ add patches to VDR*ELEC
- build single package with the -package option
- restart VDR on the device - that's it.

A quite nice setup for a development machine. There is no need to build the complete image file, transfer it and let LE/CE trigger the update process because of just one single new binary.