### PR TITLE
upgrade: delete manual links before upgrade

### DIFF
--- a/packages/vdr/_vdr/bin/vdrsternupgrade.sh
+++ b/packages/vdr/_vdr/bin/vdrsternupgrade.sh
@@ -19,6 +19,11 @@ upgrade() {
 
   # delete old sample configuration if it exists and extract the new one
   rm -Rf /storage/.config/vdropt-sample
+  # delete existing development links and files and reset them to default
+  # manual changes on the links are erased
+  # TODO: find a better solution
+  rm -Rf /storage/.config/vdrlibs/save/*
+  rm -Rf /storage/.config/vdrlibs/libvdr-*
 
   cd /
     for i in `ls ${CONF_DIR}/*-sample-config.zip`; do


### PR DESCRIPTION
otherwise, the unzip fails.

TODO: find a better solution for doing developing using the "vdrlibs" directory

fixup for https://github.com/Zabrimus/VDRSternELEC/commit/cd76abb3e63fd6578d9935b4b06af6403002f0df