### PR TITLE
add cefbrowser and remotetranscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /mybuild-amlgx.sh
 /mybuild-x86.sh
 /cmake-build-debug/
+/cef/

--- a/config/extras.list
+++ b/config/extras.list
@@ -27,3 +27,9 @@ permashift:EXTRA_PERMASHIFT
 
 # install channel logos
 channellogos:EXTRA_CHANNELLOGOS
+
+# install cefbrowser
+cefbrowser:EXTRA_CEFBROWSER
+
+# install remotetranscoder
+remotetranscode:EXTRA_REMOTETRANSCODE

--- a/packages/vdr/vdr-depends/_cef/package.mk
+++ b/packages/vdr/vdr-depends/_cef/package.mk
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+PKG_NAME="_cef"
+PKG_VERSION="114.2.11"
+PKG_LICENSE="unknown"
+PKG_SITE="https://cef-builds.spotifycdn.com/"
+PKG_URL=""
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Chromium Embedded Framework"
+PKG_TOOLCHAIN="manual"
+
+makeinstall_target() {
+  CEF_PREFIX="/storage"
+  CEF_URL="https://cef-builds.spotifycdn.com/"
+  CEF_FILE_X86="cef_binary_114.2.11%2Bg87c8807%2Bchromium-114.0.5735.134_linux64_minimal.tar.bz2"
+  CEF_FILE_ARM64="cef_binary_114.2.11%2Bg87c8807%2Bchromium-114.0.5735.134_linuxarm64_minimal.tar.bz2"
+  CEF_FILE_ARM="cef_binary_114.2.11%2Bg87c8807%2Bchromium-114.0.5735.134_linuxarm_minimal.tar.bz2"
+
+  case "${ARCH}" in
+    arm)     CEF_FILE=${CEF_FILE_ARM};;
+    aarch64) CEF_FILE=${CEF_FILE_ARM64};;
+    x86_64)  CEF_FILE=${CEF_FILE_X86};;
+  esac
+
+  # download cef
+  if [ ! -e ${PKG_BUILD}/../../../sources/${PKG_NAME}/${CEF_FILE} ]; then
+      mkdir -p ${PKG_BUILD}/../../../sources/${PKG_NAME}
+      curl -L ${CEF_URL}${CEF_FILE} -o ${PKG_BUILD}/../../../sources/${PKG_NAME}/${CEF_FILE}
+  fi
+  tar -C ${PKG_BUILD}/ -xf ${PKG_BUILD}/../../../sources/${PKG_NAME}/${CEF_FILE}
+  mv ${PKG_BUILD}/cef_binary* ${PKG_BUILD}/cefbrowser
+
+  # copy cef binaries to root/cef
+  mkdir -p ${PKG_BUILD}/../../../../cef
+  rm -f ${PKG_BUILD}/../../../../cef/cef-${ARCH}.tar.bz2
+  tar cjvf ${PKG_BUILD}/../../../../cef/cef-${ARCH}.tar.bz2 -C ${PKG_BUILD} cefbrowser/Release/* cefbrowser/Resources/*
+
+  # coreelec-19 needs this
+  sed -i "s/VERSION 3.21/VERSION 3.19/" ${PKG_BUILD}/cefbrowser/CMakeLists.txt
+}

--- a/packages/vdr/vdr-depends/_cefbrowser/package.mk
+++ b/packages/vdr/vdr-depends/_cefbrowser/package.mk
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+PKG_NAME="_cefbrowser"
+PKG_VERSION="fdd28ff3e3f9613494fb2cf4e552e59dd3a1e378"
+PKG_SHA256="c6cb848526e1ff515de1c8e90020004860e5db33a68651f2e52bde5c65c9e037"
+PKG_LICENSE="LPGL"
+PKG_SITE="https://github.com/Zabrimus/cefbrowser"
+PKG_URL="https://github.com/Zabrimus/cefbrowser/archive/${PKG_VERSION}.zip"
+PKG_SOURCE_DIR="cefbrowser-${PKG_VERSION}"
+PKG_DEPENDS_TARGET="toolchain atk libxml2 cef-at-spi2-atk cups cef-at-spi2-core \
+                    libXcomposite libXdamage libXfixes libXrandr libXi libXft openssl _cef"
+PKG_NEED_UNPACK="$(get_pkg_directory _cef)"
+PKG_LONGDESC="cefbrowser"
+PKG_TOOLCHAIN="meson"
+
+CEF_PREFIX="/storage"
+
+case "${ARCH}" in
+  arm)     DARCH="arm";;
+  aarch64) DARCH="arm64";;
+  x86_64)  DARCH="x86";;
+esac
+
+case "${ARCH}" in
+  arm)     DSUBARCH=${TARGET_SUBARCH};;
+  aarch64) DSUBARCH=${TARGET_VARIANT};;
+  x86_64)  DSUBARCH=${TARGET_SUBARCH};;
+esac
+
+PKG_MESON_OPTS_TARGET="-Darch=${DARCH} -Dsubarch=${DSUBARCH} \
+                       --prefix=${CEF_PREFIX} \
+                       --bindir=${CEF_PREFIX}/cefbrowser \
+                       --libexecdir=${CEF_PREFIX}/cefbrowser \
+                       --sbindir=${CEF_PREFIX}/cefbrowser \
+                       --libdir=${CEF_PREFIX}/cefbrowser"
+
+pre_configure_target() {
+   export SSL_CERT_FILE=$(get_install_dir openssl)/etc/ssl/cacert.pem.system
+   ln -s $(get_build_dir _cef)/cefbrowser ${PKG_BUILD}/subprojects/cef
+}
+
+pre_make_target() {
+  export PKG_CONFIG_DISABLE_SYSROOT_PREPEND="yes"
+  export LDFLAGS="$(echo ${LDFLAGS} | sed -e "s|-Wl,--as-needed||") -L${SYSROOT_PREFIX}/usr/local/lib"
+}
+
+post_makeinstall_target() {
+  rm -rf ${INSTALL}/usr/lib
+
+  mkdir -p ${INSTALL}/usr/local/config
+  cd ${INSTALL}
+  zip -qrum9 ${INSTALL}/usr/local/config/cef-sample-config.zip storage/cefbrowser
+}

--- a/packages/vdr/vdr-depends/_cefbrowser/patches/0001-fix-for-building-with-VDR-ELEC.patch
+++ b/packages/vdr/vdr-depends/_cefbrowser/patches/0001-fix-for-building-with-VDR-ELEC.patch
@@ -1,0 +1,111 @@
+From ee257ba1966f9e87dfbdd79a35da30fc1ed05b5c Mon Sep 17 00:00:00 2001
+From: Andreas Baierl <ichgeh@imkreisrum.de>
+Date: Tue, 4 Jul 2023 16:21:34 +0200
+Subject: [PATCH] fix for building with VDR*ELEC
+
+---
+ meson.build                                   | 24 ++++++++++++-------
+ meson_options.txt                             |  1 +
+ .../packagefiles/mini-0.9.14/meson.build      |  2 +-
+ .../meson.build                               |  2 +-
+ 4 files changed, 18 insertions(+), 11 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index a612fe5..f0faaee 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,11 +1,13 @@
+ project('cefbrowser', 'cpp', 'c',
+   version : '0.1',
+   default_options : ['warning_level=1', 'cpp_std=c++17', 'default_library=static', 'optimization=3' ],
+-  meson_version: '>=0.63.0')
++  meson_version: '>=0.57.1')
+ 
+ add_global_arguments('-O3', language : 'cpp')
+ 
+-arch=get_option('arch')
++arch = get_option('arch')
++subarch = '-march=' + get_option('subarch')
++install_prefix = get_option('prefix')
+ 
+ cmake = import('cmake')
+ CXX = meson.get_compiler('cpp')
+@@ -22,8 +24,12 @@ cef_opt_var = cmake.subproject_options()
+ 
+ if arch == 'arm'
+     cef_opt_var.add_cmake_defines({'PROJECT_ARCH': 'armhf'})
++    cef_opt_var.add_cmake_defines({'CMAKE_CXX_FLAGS': subarch})
++    cef_opt_var.add_cmake_defines({'CMAKE_C_FLAGS': subarch})
+ elif arch == 'arm64'
+     cef_opt_var.add_cmake_defines({'PROJECT_ARCH': 'aarch64'})
++    cef_opt_var.add_cmake_defines({'CMAKE_CXX_FLAGS': '-march=armv8-a'})
++    cef_opt_var.add_cmake_defines({'CMAKE_C_FLAGS': '-march=armv8-a'})
+ endif
+ 
+ cef_opt_var.append_compile_args('cpp', '-Wno-unused-variable')
+@@ -78,7 +84,7 @@ exe = executable('cefbrowser', 'main.cpp', 'mainapp.cpp', 'logger.cpp',
+                  'httplib.cpp',
+                  cpp_args : ['-DPHTTPLIB_ZLIB_SUPPORT', '-DCPPHTTPLIB_OPENSSL_SUPPORT'],
+                  install : true,
+-                 install_dir : meson.current_build_dir() + '/Release',
++                 link_args: '-lrt',
+                  dependencies: [mini_dep, cef_lib, spdlog_dep, deps, sqlite3_dep, dep_ssl, dep_crypto])
+ 
+ exe = executable('vdrclient', 'test-tools/vdr_tool.cpp', 'logger.cpp', 'sharedmemory.cpp', 'test-tools/common.cpp',
+@@ -86,14 +92,14 @@ exe = executable('vdrclient', 'test-tools/vdr_tool.cpp', 'logger.cpp', 'sharedme
+                 'httplib.cpp',
+                  cpp_args : ['-DCLIENT_ONLY', '-DPHTTPLIB_ZLIB_SUPPORT', '-DCPPHTTPLIB_OPENSSL_SUPPORT'],
+                  install : true,
+-                 install_dir : meson.current_build_dir() + '/Release',
++                 link_args: '-lrt',
+                  dependencies: [mini_dep, spdlog_dep, deps, tiny_process_library_dep, dep_ssl, dep_crypto])
+ 
+ #
+ # install static content
+ #
+-install_subdir('static-content/js', install_dir : meson.current_build_dir() + '/Release')
+-install_subdir('static-content/css', install_dir : meson.current_build_dir() + '/Release')
+-install_subdir('static-content/movie', install_dir : meson.current_build_dir() + '/Release')
+-install_subdir('static-content/database', install_dir : meson.current_build_dir() + '/Release')
+-install_subdir('static-content/application', install_dir : meson.current_build_dir() + '/Release')
++install_subdir('static-content/js', install_dir : 'cefbrowser')
++install_subdir('static-content/css', install_dir : 'cefbrowser')
++install_subdir('static-content/movie', install_dir : 'cefbrowser')
++install_subdir('static-content/database', install_dir : 'cefbrowser')
++install_subdir('static-content/application', install_dir : 'cefbrowser')
+diff --git a/meson_options.txt b/meson_options.txt
+index f1b0b7b..b571a75 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -1 +1,2 @@
+ option('arch', type : 'combo', choices : ['x86', 'arm', 'arm64'], value : 'x86')
++option('subarch', type : 'string', value : 'armv8-a')
+diff --git a/subprojects/packagefiles/mini-0.9.14/meson.build b/subprojects/packagefiles/mini-0.9.14/meson.build
+index 9136107..c4f7f36 100644
+--- a/subprojects/packagefiles/mini-0.9.14/meson.build
++++ b/subprojects/packagefiles/mini-0.9.14/meson.build
+@@ -4,7 +4,7 @@ project(
+   version: '0.8.5',
+   license: 'Apache-2.0 license',
+   default_options: ['cpp_std=c++17'],
+-  meson_version: '>=0.63.0',
++  meson_version: '>=0.57.1',
+ )
+ 
+ inc = include_directories('src')
+diff --git a/subprojects/packagefiles/tiny-process-library-4bf0e59e64f18d3080a1ce4e853775de2181e993/meson.build b/subprojects/packagefiles/tiny-process-library-4bf0e59e64f18d3080a1ce4e853775de2181e993/meson.build
+index 4d0e048..815d8f6 100644
+--- a/subprojects/packagefiles/tiny-process-library-4bf0e59e64f18d3080a1ce4e853775de2181e993/meson.build
++++ b/subprojects/packagefiles/tiny-process-library-4bf0e59e64f18d3080a1ce4e853775de2181e993/meson.build
+@@ -4,7 +4,7 @@ project(
+   version: '4bf0e59e64f18d3080a1ce4e853775de2181e993',
+   license: 'MIT',
+   default_options: ['cpp_std=c++17'],
+-  meson_version: '>=0.63.0',
++  meson_version: '>=0.57.1',
+ )
+ 
+ src = files(
+-- 
+2.30.2
+

--- a/packages/vdr/vdr-depends/_cefbrowser/system.d/cefbrowser.service
+++ b/packages/vdr/vdr-depends/_cefbrowser/system.d/cefbrowser.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=cefbrowser
+Requires=network-online.target
+After=network-online.target
+StartLimitIntervalSec=400
+StartLimitBurst=5
+
+[Service]
+WorkingDirectory=/storage/cefbrowser
+ExecStart=/storage/cefbrowser/cefbrowser --config /storage/.config/vdropt/sockets.ini --ozone-platform=headless
+Restart=always
+RestartSec=30
+Environment=LD_LIBRARY_PATH="/storage/cefbrowser"
+StartLimitInterval=0
+TimeoutStartSec=30
+TimeoutStopSec=30
+LimitNOFILE=16384
+
+[Install]
+WantedBy=vdropt.target

--- a/packages/vdr/vdr-depends/_remotetranscode/package.mk
+++ b/packages/vdr/vdr-depends/_remotetranscode/package.mk
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+PKG_NAME="_remotetranscode"
+PKG_VERSION="b96408227543c96a775a928491bb779487890495"
+PKG_SHA256="1779db79152d184d7939c045a30d27d1b39cd1730f27422923f5400432050d2c"
+PKG_LICENSE="unknown"
+PKG_SITE="https://github.com/Zabrimus/remotetranscode"
+PKG_URL="https://github.com/Zabrimus/remotetranscode/archive/${PKG_VERSION}.zip"
+PKG_SOURCE_DIR="remotetranscode-${PKG_VERSION}"
+PKG_DEPENDS_TARGET="toolchain ffmpeg"
+PKG_LONGDESC="remotetranscode"
+PKG_TOOLCHAIN="meson"
+
+RT_PREFIX="/storage"
+
+PKG_MESON_OPTS_TARGET="--prefix=${RT_PREFIX} \
+                       --bindir=${RT_PREFIX}/remotetranscode \
+                       --libexecdir=${RT_PREFIX}/remotetranscode \
+                       --sbindir=${RT_PREFIX}/remotetranscode \
+                       --libdir=${RT_PREFIX}/remotetranscode"
+
+pre_configure_target() {
+   export SSL_CERT_FILE=$(get_install_dir openssl)/etc/ssl/cacert.pem.system
+}
+
+pre_make_target() {
+  export PKG_CONFIG_DISABLE_SYSROOT_PREPEND="yes"
+  export LDFLAGS="$(echo ${LDFLAGS} | sed -e "s|-Wl,--as-needed||") -L${SYSROOT_PREFIX}/usr/local/lib"
+}
+
+post_makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/local/config
+  cd ${INSTALL}
+  zip -qrum9 ${INSTALL}/usr/local/config/remotetranscode-sample-config.zip storage/remotetranscode
+}

--- a/packages/vdr/vdr-depends/_remotetranscode/patches/0001-fix-build-for-VE.patch
+++ b/packages/vdr/vdr-depends/_remotetranscode/patches/0001-fix-build-for-VE.patch
@@ -1,0 +1,55 @@
+From ae8aa5d6700403fb27538dea741dd073f39746ac Mon Sep 17 00:00:00 2001
+From: Andreas Baierl <ichgeh@imkreisrum.de>
+Date: Wed, 26 Jul 2023 11:09:25 +0200
+Subject: [PATCH] fix build for VE
+
+---
+ ffmpeghandler.cpp | 2 +-
+ meson.build       | 7 ++++---
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/ffmpeghandler.cpp b/ffmpeghandler.cpp
+index 67e3050..3604710 100644
+--- a/ffmpeghandler.cpp
++++ b/ffmpeghandler.cpp
+@@ -197,7 +197,7 @@ bool FFmpegHandler::probe(const std::string& url) {
+     // get stream infos
+     DEBUG("Starte ffprobe");
+     std::vector<std::string> callStr {
+-        "ffprobe", "-y", "-i", url,
++        "ffprobe", "-i", url,
+         "-loglevel", "quiet",
+         "-print_format", "csv",
+         "-show_entries", "format=duration",
+diff --git a/meson.build b/meson.build
+index 9a2ea1e..7640906 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,9 +1,10 @@
+ project('remotetranscode', 'cpp', 'c',
+   version : '0.1',
+   default_options : ['warning_level=1', 'c_std=c17', 'cpp_std=c++17'],
+-  meson_version: '>=0.63.0')
++  meson_version: '>=0.56.2')
+ 
+ add_global_arguments(language : 'cpp')
++install_prefix = get_option('prefix')
+ 
+ cmake = import('cmake')
+ cpp = meson.get_compiler('cpp')
+@@ -29,10 +30,10 @@ mini_dep = mini_proj.get_variable('mini_dep')
+ 
+ 
+ exe = executable('remotrans', 'main.cpp', 'logger.cpp', 'ffmpeghandler.cpp', 'browserclient.cpp',
+-                 install : false,
++                 install : true,
+                  dependencies: [mini_dep, spdlog_dep, tiny_process_library_dep])
+ 
+ #
+ # install static content
+ #
+-install_subdir('static-content/movie', install_dir : meson.current_build_dir())
++install_subdir('static-content/movie', install_dir : 'remotetranscode')
+-- 
+2.30.2
+

--- a/packages/vdr/vdr-depends/_remotetranscode/system.d/remotetranscode.service
+++ b/packages/vdr/vdr-depends/_remotetranscode/system.d/remotetranscode.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=remotetranscode
+Requires=network-online.target
+After=network-online.target
+StartLimitIntervalSec=400
+StartLimitBurst=5
+
+[Service]
+WorkingDirectory=/storage/remotetranscode
+ExecStart=/storage/remotetranscode/remotrans -c /storage/.config/vdropt/sockets.ini
+Restart=always
+RestartSec=30
+StartLimitInterval=0
+TimeoutStartSec=30
+TimeoutStopSec=30
+LimitNOFILE=16384
+
+[Install]
+WantedBy=vdropt.target

--- a/packages/vdr/vdr-depends/cef-at-spi2-atk/package.mk
+++ b/packages/vdr/vdr-depends/cef-at-spi2-atk/package.mk
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2017 Escalade
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+. $(get_pkg_directory at-spi2-atk)/package.mk
+
+PKG_NAME="cef-at-spi2-atk"
+PKG_LONGDESC="A GTK+ module that bridges ATK to D-Bus at-spi, built for cef."
+PKG_URL=""
+PKG_DEPENDS_TARGET="toolchain cef-at-spi2-core atk libxml2"
+PKG_DEPENDS_UNPACK+=" at-spi2-atk"
+
+unpack() {
+  mkdir -p ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:4}/${PKG_NAME:4}-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
+}

--- a/packages/vdr/vdr-depends/cef-at-spi2-core/package.mk
+++ b/packages/vdr/vdr-depends/cef-at-spi2-core/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2017 Escalade
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+. $(get_pkg_directory at-spi2-core)/package.mk
+
+PKG_NAME="cef-at-spi2-core"
+PKG_LONGDESC="Protocol definitions and daemon for D-Bus at-spi, built with libXtst."
+PKG_URL=""
+PKG_DEPENDS_UNPACK+=" at-spi2-core"
+PKG_DEPENDS_TARGET+=" libXtst"
+#PKG_BUILD_FLAGS="-sysroot"
+
+unpack() {
+  mkdir -p ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:4}/${PKG_NAME:4}-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
+}

--- a/packages/virtual/vdr-all/package.mk
+++ b/packages/virtual/vdr-all/package.mk
@@ -131,6 +131,14 @@ if [ "${EXTRA_CHANNELLOGOS}" = "y" ]; then
 	PKG_DEPENDS_TARGET+=" _MP_Logos"
 fi
 
+if [ "${EXTRA_CEFBROWSER}" = "y" ]; then
+	PKG_DEPENDS_TARGET+=" _cefbrowser"
+fi
+
+if [ "${EXTRA_REMOTETRANSCODE}" = "y" ]; then
+	PKG_DEPENDS_TARGET+=" _remotetranscode"
+fi
+
 post_install() {
   if [ "${PROJECT} = "Amlogic-ce" ] || [ "${PROJECT} = "Amlogic" ]; then
      # Fix some links

--- a/patches/LibreELEC.tv/0001-build-ffmpeg-programs.patch
+++ b/patches/LibreELEC.tv/0001-build-ffmpeg-programs.patch
@@ -1,0 +1,95 @@
+From 4080828fb7cd1fee5ffa75a17fbfe7b8278fbd2f Mon Sep 17 00:00:00 2001
+From: Andreas Baierl <ichgeh@imkreisrum.de>
+Date: Wed, 26 Jul 2023 11:05:54 +0200
+Subject: [PATCH] build ffmpeg programs
+
+---
+ packages/addons/addon-depends/opus/package.mk |  2 +-
+ packages/audio/libvorbis/package.mk           |  2 +-
+ packages/multimedia/ffmpeg/package.mk         | 20 +++++++++++++++----
+ 3 files changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/packages/addons/addon-depends/opus/package.mk b/packages/addons/addon-depends/opus/package.mk
+index 83bb5e61af..d635265b71 100644
+--- a/packages/addons/addon-depends/opus/package.mk
++++ b/packages/addons/addon-depends/opus/package.mk
+@@ -19,5 +19,5 @@ else
+ fi
+ 
+ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
+-                           --disable-shared \
++                           --enable-shared \
+                            ${PKG_FIXED_POINT}"
+diff --git a/packages/audio/libvorbis/package.mk b/packages/audio/libvorbis/package.mk
+index 2b72481931..72d6a15f67 100644
+--- a/packages/audio/libvorbis/package.mk
++++ b/packages/audio/libvorbis/package.mk
+@@ -14,7 +14,7 @@ PKG_TOOLCHAIN="autotools"
+ PKG_BUILD_FLAGS="+pic"
+ 
+ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
+-                           --disable-shared \
++                           --enable-shared \
+                            --with-ogg=${SYSROOT_PREFIX}/usr \
+                            --disable-docs \
+                            --disable-examples \
+diff --git a/packages/multimedia/ffmpeg/package.mk b/packages/multimedia/ffmpeg/package.mk
+index cb0d4ae22a..c457ab97e9 100644
+--- a/packages/multimedia/ffmpeg/package.mk
++++ b/packages/multimedia/ffmpeg/package.mk
+@@ -8,7 +8,7 @@ PKG_SHA256="57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082"
+ PKG_LICENSE="GPL-3.0-only"
+ PKG_SITE="https://ffmpeg.org"
+ PKG_URL="http://ffmpeg.org/releases/ffmpeg-${PKG_VERSION}.tar.xz"
+-PKG_DEPENDS_TARGET="toolchain zlib bzip2 openssl speex"
++PKG_DEPENDS_TARGET="toolchain zlib bzip2 openssl speex libvpx libvorbis opus"
+ PKG_LONGDESC="FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video."
+ PKG_PATCH_DIRS="libreelec"
+ 
+@@ -125,7 +126,7 @@ if [ "${FFMPEG_TESTING}" = "yes" ]; then
+     PKG_FFMPEG_TESTING+=" --enable-vout-drm --enable-outdev=vout_drm"
+   fi
+ else
+-  PKG_FFMPEG_TESTING="--disable-programs"
++  PKG_FFMPEG_TESTING=""
+ fi
+ 
+ configure_target() {
+@@ -188,6 +189,13 @@ configure_target() {
+               --enable-encoder=aac \
+               --enable-encoder=wmav2 \
+               --enable-encoder=mjpeg \
++              --enable-libvpx \
++              --enable-encoder=libvpx_vp8 \
++              --enable-encoder=libvpx_vp9 \
++              --enable-libvorbis \
++              --enable-libopus \
++              --enable-encoder=libvorbis \
++              --enable-encoder=libopus \
+               --enable-encoder=png \
+               ${PKG_FFMPEG_HWACCEL} \
+               --disable-muxers \
+@@ -196,6 +205,11 @@ configure_target() {
+               --enable-muxer=asf \
+               --enable-muxer=ipod \
+               --enable-muxer=mpegts \
++              --enable-muxer=matroska \
++              --enable-muxer=mp4 \
++              --enable-muxer=webm \
++              --enable-muxer=webm_chunk \
++              --enable-muxer=webm_dash_manifest \
+               --enable-demuxers \
+               --enable-parsers \
+               --enable-bsfs \
+@@ -221,8 +235,6 @@ configure_target() {
+               --enable-libspeex \
+               --disable-libtheora \
+               --disable-libvo-amrwbenc \
+-              --disable-libvorbis \
+-              --disable-libvpx \
+               --disable-libx264 \
+               --disable-libxavs \
+               --disable-libxvid \
+-- 
+2.30.2
+


### PR DESCRIPTION
the cef binaries will stay in VDRSternELEC/cef as a tar.bz2 and must be manually copied and extracted on the target
the cefbrowser will be handled like the vdr config files and must be installed with the install script

the image does not include the binaries, because they are too big and only needed once.

TODO: probably implement this as an addon

only tested with LE master/ Rockchip